### PR TITLE
fix: strip leading ! from whohas node identifier (#12)

### DIFF
--- a/MeshNodes/commands/InfoCommands.py
+++ b/MeshNodes/commands/InfoCommands.py
@@ -192,6 +192,8 @@ async def node_info(mesh_nodes, ctx, *identifier: str):
         return
 
     identifier = " ".join(identifier).strip()
+    if identifier.startswith("!"):
+        identifier = identifier[1:]
 
     loading_message = await ctx.send(mesh_nodes.get_random_loading_message())
 


### PR DESCRIPTION
## Summary

Closes #12.

The Meshtastic app copies node IDs with a leading `!` (e.g. `!a20a1708`), but the bot stores and matches node IDs as 8-char hex without the prefix. Passing the copied value to `!whohas` / `!node` / `!nodeinfo` produced a 9-char identifier that bypassed the node-ID branch entirely (which only runs when `len(identifier) <= 8`), so the lookup silently fell through to shortname/longname matching and reported "Node not found".

## Change

`node_info` in `MeshNodes/commands/InfoCommands.py` now strips a single leading `!` from the joined identifier before the existing match logic runs. Two-line change, no new dependencies, no schema change.

```python
identifier = " ".join(identifier).strip()
if identifier.startswith("!"):
    identifier = identifier[1:]
```

After stripping, the existing branches handle everything:

| Input         | After strip | Matches via                       |
|---------------|-------------|-----------------------------------|
| `!a20a1708`   | `a20a1708`  | exact 8-char `node_id`            |
| `!1708`       | `1708`      | partial trailing `node_id` match  |
| `a20a1708`    | `a20a1708`  | unchanged — exact `node_id`       |
| `1708`        | `1708`      | unchanged — partial `node_id`     |
| `MSP`         | `MSP`       | unchanged — exact `short_name`    |

No collision risk on shortnames: the paperwork modal (`register_node`) already strips leading `!` on insert, so no stored shortname can begin with `!`.

## Scope

Intentionally limited to `node_info` per issue #12 ("node command"). The same latent bug exists in `full_node_info`, `edit_node`, `transfer_node`, `clear_additional_node_info`, and `edit_additional_node_info` — each requires `len == 8` and would also choke on the `!` prefix. Leaving those for follow-up issues to keep this PR focused and easy to review.

## Test plan

No automated test infra exists in the repo, so this is manual:

- [ ] `!whohas !a20a1708` — finds the node (previously failed)
- [ ] `!whohas a20a1708` — still finds the node (regression check)
- [ ] `!whohas !1708` — finds the node via partial trailing match
- [ ] `!whohas 1708` — still finds the node via partial trailing match
- [ ] `!whohas MSP` — shortname match still works
- [ ] `!whohas <longname with spaces>` — longname match still works
- [ ] `!whohas !doesnotexist` — returns the standard "Node not found" message
- [ ] `!node` and `!nodeinfo` aliases behave identically to `!whohas`

🤖 Generated with [Claude Code](https://claude.com/claude-code)